### PR TITLE
fix badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - /^release-.*$/
     paths:
       - '.github/workflows/ci.yml'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Documentation
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: '*'
     paths:
       - '.github/workflows/docs.yml'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://github.com/beacon-biosignals/KeywordSearch.jl/workflows/CI/badge.svg)](https://github.com/beacon-biosignals/KeywordSearch.jl/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/beacon-biosignals/KeywordSearch.jl/branch/main/badge.svg)](https://app.codecov.io/gh/beacon-biosignals/KeywordSearch.jl)
+[![Build Status](https://github.com/beacon-biosignals/KeywordSearch.jl/workflows/CI/badge.svg?branch=main)](https://github.com/beacon-biosignals/KeywordSearch.jl/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/beacon-biosignals/KeywordSearch.jl/branch/main/graph/badge.svg?token=0HRHZ1BL60)](https://codecov.io/gh/beacon-biosignals/KeywordSearch.jl)
 
 # KeywordSearch
 


### PR DESCRIPTION
* forgot to update CI to run on commits to `main` instead of `master`
* README CI badge needs `branch` argument to not point to PR build statuses
* codecov badge seems to need a token, but this doesn't work yet:

[![codecov](https://codecov.io/gh/beacon-biosignals/KeywordSearch.jl/branch/main/graph/badge.svg?token=0HRHZ1BL60)](https://codecov.io/gh/beacon-biosignals/KeywordSearch.jl)

I think codecov just needs to be enabled for this repo
