### PR TITLE
Remove `And`

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,3 +1,0 @@
-# Quick tutorial
-
-KeywordSearch  

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,0 +1,3 @@
+# Quick tutorial
+
+KeywordSearch  

--- a/src/KeywordSearch.jl
+++ b/src/KeywordSearch.jl
@@ -16,7 +16,6 @@ For example, if `KeywordSearch.AUTOMATIC_REPLACEMENTS == ["a" => "b"]`, then
 """
 const AUTOMATIC_REPLACEMENTS = Pair{String, String}[]
 
-include("match.jl")
 include("core.jl")
 include("corpus.jl")
 include("names.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -39,6 +39,13 @@ function process_punct(str::AbstractString)
     return replace(str, r"[.!?><\\-]" => " ")
 end
 
+struct QueryMatch{Q,H,D,I}
+    query::Q
+    haystack::H
+    distance::D
+    indices::I
+end
+
 abstract type AbstractQuery end
 
 struct Query <: AbstractQuery

--- a/src/core.jl
+++ b/src/core.jl
@@ -96,29 +96,7 @@ end
 
 Or(q1::AbstractQuery, q2::AbstractQuery) = Or((q1, q2))
 
-struct And{S<:Tuple} <: AbstractQuery
-    subqueries::S
-end
-
-# This is type-unstable...
-function Base.match(Q::And, R::Document)
-    matches = tuple()
-    for subquery in Q.subqueries
-        m = match(subquery, R)
-        m === nothing && return nothing
-        matches = (matches..., m)
-    end
-    return AndMatch(matches)
-end
-
-# Specializations to combine And's
-And(q1::And, q2::AbstractQuery) = And((q1.subqueries..., q2))
-And(q1::AbstractQuery, q2::And) = And((q1, q2.subqueries...))
-And(q1::And, q2::And) = And((q1.subqueries..., q2.subqueries...))
-And(q1::AbstractQuery, q2::AbstractQuery) = And((q1, q2))
-
 Base.:(|)(q1::AbstractQuery, q2::AbstractQuery) = Or(q1, q2)
-Base.:(&)(q1::AbstractQuery, q2::AbstractQuery) = And(q1, q2)
 
 struct FuzzyQuery{D,T} <: AbstractQuery
     text::String

--- a/src/match.jl
+++ b/src/match.jl
@@ -1,6 +1,0 @@
-struct QueryMatch{Q,H,D,I}
-    query::Q
-    haystack::H
-    distance::D
-    indices::I
-end

--- a/src/match.jl
+++ b/src/match.jl
@@ -1,16 +1,6 @@
-abstract type AbstractMatch end
-
-struct QueryMatch{Q,H,D,I} <: AbstractMatch
+struct QueryMatch{Q,H,D,I}
     query::Q
     haystack::H
     distance::D
     indices::I
-end
-
-# We make a new object instead of using an array or tuple of
-# `QueryMatch`'s directly, since semantically an `AndMatch`
-# is a new object, a single match to an `And` query that consists
-# of a match for each query that is being `And`'d together.
-struct AndMatch{Q} <: AbstractMatch
-    matches::Q
 end

--- a/src/names.jl
+++ b/src/names.jl
@@ -1,4 +1,4 @@
-struct NamedMatch{T,M<:AbstractMatch} <: AbstractMatch
+struct NamedMatch{T,M<:QueryMatch}
     match::M
     metadata::T
     function NamedMatch(match::M, metadata::T) where {M,T}

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -13,12 +13,10 @@ AbstractTrees.children(q::NamedMatch) = (NoChildren(q.metadata), q.match)
 AbstractTrees.children(q::QueryMatch) = (q.query, q.haystack)
 
 AbstractTrees.children(q::Or) = q.subqueries
-AbstractTrees.children(q::And) = q.subqueries
 AbstractTrees.children(q::Query) = tuple()
 AbstractTrees.children(q::FuzzyQuery) = tuple()
 
 AbstractTrees.printnode(io::IO, q::Or) = print(io, "Or")
-AbstractTrees.printnode(io::IO, q::And) = print(io, "And")
 AbstractTrees.printnode(io::IO, q::NamedQuery) = print(io, "NamedQuery")
 AbstractTrees.printnode(io::IO, q::NamedMatch) = print(io, "NamedMatch")
 
@@ -36,7 +34,7 @@ function print_tree_rstrip(io::IO, x)
     return nothing
 end
 
-Base.show(io::IO, q::Union{And,Or,NamedQuery,NamedMatch}) = print_tree_rstrip(io, q)
+Base.show(io::IO, q::Union{Or,NamedQuery,NamedMatch}) = print_tree_rstrip(io, q)
 
 # `text_left_endpoint` and `text_right_endpoint` could be combined
 # but it would probably be too clever... let's just duplicate it
@@ -145,7 +143,7 @@ function explain(io::IO, m::QueryMatch{Query}; context=40)
     return nothing
 end
 
-explain(m::AbstractMatch; context=40) = explain(stdout, m; context=context)
+explain(m; context=40) = explain(stdout, m; context=context)
 
 function Base.show(io::IO, m::QueryMatch)
     return print(io, "QueryMatch with distance ", m.distance, " at indices ", m.indices, ".")


### PR DESCRIPTION
There's a couple reasons for this:

* it's not very useful: it I only used it once in the queries I've been doing for Beacon, and you can easily replicate the logic outside of KeywordSearch. E.g. to search for "keyword 1" and "keyword 2", simply search for "keyword 1" and if a match is found, then search for "keyword 2".
    * Of course, you could also replicate `Or` outside of KeywordSearch, but in KeywordSearch itself we generate Or queries (by augmenting things like "arctic wolf" -> ("arctic wolf" OR "arcticwolf") so it's very convenient to treat those as a single query (since the user gave a single query in the first place). We don't generate `And`s though.
* In downstream code, I found it very useful to be able to assume matches in `NamedMatch` were `QueryMatches`, not something else (the other possibility being `AndMatch`), so that I can get access to things like the distance of the match and the indices where the match occurred. This doesn't make sense for `AndMatch`, because there are multiple submatches.
* it adds complexity

This PR is branched off #4 instead of main since I was worried about conflicts although in retrospect it would probably have been fine.