### PR TITLE
extend table interface for `NamedMatch`es

### DIFF
--- a/src/names.jl
+++ b/src/names.jl
@@ -7,9 +7,35 @@ struct NamedMatch{T,M<:QueryMatch}
     end
 end
 
-Tables.getcolumn(m::NamedMatch, i::Int) = i == 1 ? m.match : m.metadata[i - 1]
-Tables.getcolumn(m::NamedMatch, s::Symbol) = s === :match ? m.match : m.metadata[s]
-Tables.columnnames(m::NamedMatch) = (:match, keys(m.metadata)...)
+function Tables.getcolumn(m::NamedMatch, i::Int)
+    if i === 1
+        return m.match.query
+    elseif i === 2
+        return m.match.haystack
+    elseif i === 3
+        return m.match.distance
+    elseif i === 4
+        return m.match.indices
+    else
+        return m.metadata[i - 4]
+    end
+end
+
+function Tables.getcolumn(m::NamedMatch, s::Symbol)
+    if s === :query
+        return m.match.query
+    elseif s === :haystack
+        return m.match.haystack
+    elseif s === :distance
+        return m.match.distance
+    elseif s === :indices
+        return m.match.indices
+    else
+        return m.metadata[s]
+    end
+end
+
+Tables.columnnames(m::NamedMatch) = (:haystack, :distance, :indices, :query, keys(m.metadata)...)
 Tables.isrowtable(::Type{<:AbstractVector{<:NamedMatch}}) = true
 
 explain(io::IO, m::NamedMatch; context=40) = explain(io, m.match; context=context)

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -143,6 +143,13 @@ function explain(io::IO, m::QueryMatch{Query}; context=40)
     return nothing
 end
 
+# in case we no longer have a `QueryMatch` but at least have a row-like
+# object with the right fields.
+function explain(io::IO, row; context=40)
+    match = QueryMatch(row.query, row.haystack, row.distance, row.indices)
+    return explain(io, match; context=context)
+end
+
 explain(m; context=40) = explain(stdout, m; context=context)
 
 function Base.show(io::IO, m::QueryMatch)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -402,10 +402,11 @@ end
 
     @testset "Tables interface for `NamedMatch`s" begin
         tbl = [res, res]
-        @test Tables.getcolumn(res, 2) == "other"
+        @test Tables.getcolumn(res, 5) == "other"
         @test Tables.isrowtable(tbl)
         @test Tables.columns(tbl).query_name == ["other", "other"]
-        @test Tables.columnnames(res) == (:match, :query_name, :corpus_uuid, :document_uuid)
+        @test Tables.columnnames(res) == (:haystack, :distance, :indices, :query, :query_name, :corpus_uuid, :document_uuid)
+        @test sprint(explain, (first(Tables.rowtable(tbl)))) === "The query \" other\" exactly matched the text \"There were other cobras \".\n"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -401,8 +401,13 @@ end
     @test match(Q, D4).metadata == (; query_name="other", document_uuid=d_uuid)
 
     @testset "Tables interface for `NamedMatch`s" begin
+        @test Tables.getcolumn(res, 1) == Tables.getcolumn(res, :query) == Q.query
+        @test Tables.getcolumn(res, 2) == Tables.getcolumn(res, :haystack) == D4
+        @test Tables.getcolumn(res, 3) == Tables.getcolumn(res, :distance) == 0
+        @test Tables.getcolumn(res, 4) == Tables.getcolumn(res, :indices)
+        @test Tables.getcolumn(res, 5) == Tables.getcolumn(res, :query_name) == "other"
+        @test Tables.getcolumn(res, 6) == Tables.getcolumn(res, :corpus_uuid) == C2_uuid
         tbl = [res, res]
-        @test Tables.getcolumn(res, 5) == "other"
         @test Tables.isrowtable(tbl)
         @test Tables.columns(tbl).query_name == ["other", "other"]
         @test Tables.columnnames(res) == (:haystack, :distance, :indices, :query, :query_name, :corpus_uuid, :document_uuid)


### PR DESCRIPTION
I had originally just extended out the metadata and kept the match, but I think it's more convenient to just include all the fields. The `QueryMatch` object can be recreated as in the new `explain` method, which lets you explain rows of the tables.