### PR TITLE
improve documentation, add doctests, fix bugs found on the way

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,15 +12,17 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 AbstractTrees = "0.3"
 Aqua = "0.5"
+Documenter = "0.25"
 StringDistances = "0.10"
 Tables = "1"
 julia = "1.5"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "Random", "Suppressor"]
+test = ["Aqua", "Documenter", "Test", "Random", "Suppressor"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,9 +2,11 @@
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 KeywordSearch = "f977ba8c-7144-47e8-b06b-e3f658952959"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]
 DataFrames = "0.22"
 Documenter = "0.25"
+Tables = "1"
 Transducers = "0.4"

--- a/docs/fix_doctests.jl
+++ b/docs/fix_doctests.jl
@@ -1,0 +1,12 @@
+# run this script in the `docs` project to fix the doctests if they are out of date
+# carefully review the changes before committing!
+
+using Documenter, KeywordSearch
+
+DocMeta.setdocmeta!(KeywordSearch, :DocTestSetup, :(using KeywordSearch); recursive=true)
+
+if success(`git diff --quiet`)
+    doctest(KeywordSearch, fix=true)
+else
+    error("Git repo dirty; commit changes before fixing doctests.")
+end

--- a/docs/fix_doctests.jl
+++ b/docs/fix_doctests.jl
@@ -6,7 +6,7 @@ using Documenter, KeywordSearch
 DocMeta.setdocmeta!(KeywordSearch, :DocTestSetup, :(using KeywordSearch); recursive=true)
 
 if success(`git diff --quiet`)
-    doctest(KeywordSearch, fix=true)
+    doctest(KeywordSearch; fix=true)
 else
     error("Git repo dirty; commit changes before fixing doctests.")
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,9 +3,11 @@ using Documenter
 
 makedocs(; modules=[KeywordSearch], sitename="KeywordSearch",
          authors="Beacon Biosignals and other contributors",
-         pages=["Home" => "index.md", "Quick tutorial" => "tutorial.md",
-                "Tables of queries" => "named_queries.md",
-                "API Documentation" => "api_documentation.md"])
+         pages=["Home" => "index.md",
+                "Quick tutorial" => "tutorial.md",
+                "Tables of matches" => "named_queries.md",
+                "API Documentation" => "api_documentation.md"],
+         )
 
 deploydocs(; repo="github.com/beacon-biosignals/KeywordSearch.jl.git", devbranch="main",
            push_preview=true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,10 @@
 using KeywordSearch
 using Documenter
 
-makedocs(; modules=[KeywordSearch], sitename="KeywordSearch",
+DocMeta.setdocmeta!(KeywordSearch, :DocTestSetup, :(using KeywordSearch); recursive=true)
+
+makedocs(modules=[KeywordSearch],
+         sitename="KeywordSearch",
          authors="Beacon Biosignals and other contributors",
          pages=["Home" => "index.md",
                 "Quick tutorial" => "tutorial.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,14 +3,11 @@ using Documenter
 
 DocMeta.setdocmeta!(KeywordSearch, :DocTestSetup, :(using KeywordSearch); recursive=true)
 
-makedocs(modules=[KeywordSearch],
-         sitename="KeywordSearch",
+makedocs(; modules=[KeywordSearch], sitename="KeywordSearch",
          authors="Beacon Biosignals and other contributors",
-         pages=["Home" => "index.md",
-                "Quick tutorial" => "tutorial.md",
+         pages=["Home" => "index.md", "Quick tutorial" => "tutorial.md",
                 "Tables of matches" => "named_queries.md",
-                "API Documentation" => "api_documentation.md"],
-         )
+                "API Documentation" => "api_documentation.md"])
 
 deploydocs(; repo="github.com/beacon-biosignals/KeywordSearch.jl.git", devbranch="main",
            push_preview=true)

--- a/docs/src/api_documentation.md
+++ b/docs/src/api_documentation.md
@@ -5,8 +5,20 @@ CurrentModule = KeywordSearch
 ```
 
 
+## Public API
 
-```@autodocs
-Modules = [KeywordSearch]
-Order   = [:type, :constant, :function]
+```@docs
+Document
+Corpus
+Query
+FuzzyQuery
+NamedQuery
+QueryMatch
+NamedMatch
+match
+match_all
+explain
+augment
+word_boundary
+AUTOMATIC_REPLACEMENTS
 ```

--- a/docs/src/api_documentation.md
+++ b/docs/src/api_documentation.md
@@ -4,21 +4,46 @@
 CurrentModule = KeywordSearch
 ```
 
-
-## Public API
+## Queries
 
 ```@docs
-Document
-Corpus
 Query
 FuzzyQuery
 NamedQuery
+```
+
+## Documents
+```@docs
+Document
+match(::AbstractQuery, ::Document)
+match_all(::AbstractQuery, ::Document)
+```
+
+## Corpuses
+
+```@docs
+Corpus
+match(::AbstractQuery, ::Corpus)
+match_all(::AbstractQuery, ::Corpus)
+```
+
+## Matches
+
+```@docs
 QueryMatch
 NamedMatch
-match
-match_all
+```
+
+## Helper functions
+
+```@docs
 explain
 augment
 word_boundary
+```
+
+## Constants
+
+```@docs
 AUTOMATIC_REPLACEMENTS
 ```

--- a/docs/src/api_documentation.md
+++ b/docs/src/api_documentation.md
@@ -13,6 +13,7 @@ NamedQuery
 ```
 
 ## Documents
+
 ```@docs
 Document
 match(::AbstractQuery, ::Document)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,8 @@ KeywordSearch has two main nouns:
 Documents may also be collected into a [`Corpus`](@ref), which is simply a `Vector` of `Document`s
 with additional metadata. Here, metadata simply refers to any `NamedTuple` stored in the `.metadata` field of the object.
 
-Queries are used to search `Document`s or `Corpus`s via `Base.match`. If no match is found, `nothing` is returned; otherwise, a [`KeywordSearch.QueryMatch`](@ref) object is returned which contains details of the match.
+Queries are used to search `Document`s or `Corpus`s via [`Base.match`](@ref) or [`match_all`](@ref). If no match is found, `nothing` is returned;
+otherwise, a [`KeywordSearch.QueryMatch`](@ref) object is returned which contains details of the match.
 
 ## Contents
 

--- a/docs/src/named_queries.md
+++ b/docs/src/named_queries.md
@@ -1,4 +1,6 @@
-# Named queries
+# Tables of matches
+
+via [`NamedQuery`](@ref)s.
 
 ```@repl 2
 using KeywordSearch, Random, DataFrames

--- a/src/core.jl
+++ b/src/core.jl
@@ -75,6 +75,23 @@ struct Query <: AbstractQuery
     Query(str::AbstractString) = new(process_punct(str))
 end
 
+
+"""
+    Base.match(query::AbstractQuery, text::Union{Document,Corpus})
+
+Looks for a match for `query` in the text. Returns either `nothing`
+if no match is found, or a [`QueryMatch`](@ref) object.
+"""
+Base.match(query::AbstractQuery, text::Union{Document,Corpus})
+
+"""
+    match_all(query::AbstractQuery, text::Union{Document,Corpus})
+
+Looks for all matches for `query` in the text. Returns either a
+`Vector` `QueryMatch` objects corresponding to all of the matches found.
+"""
+match_all(query::AbstractQuery, text::Union{Document,Corpus})
+
 function Base.match(Q::Query, R::Document)
     if (length(R.text) < length(Q.text)) || (length(Q.text) == 0)
         return nothing

--- a/src/core.jl
+++ b/src/core.jl
@@ -85,7 +85,6 @@ if no match is found, or a [`QueryMatch`](@ref) object.
 """
 Base.match(query::AbstractQuery, document::Document)
 
-
 """
     match_all(query::AbstractQuery, document::Document)
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,4 +1,6 @@
-"""
+# `@doc` needed for using a `raw` string as a docstring; raw needed because
+# of the escape characters in the regex.
+@doc raw"""
     Document{T<:NamedTuple}
 
 Represents a single string document. This object has two fields,
@@ -8,7 +10,7 @@ Represents a single string document. This object has two fields,
 
 The `text` is automatically processed by first applying the replacements
 from [`AUTOMATIC_REPLACEMENTS`](@ref), then replacing punctuation
-matching `r"[.!?><\\-]"` by spaces, and  finally by
+matching `r"[.!?><\-\n\r\v\t\f]"` by spaces, and  finally by
 adding a space to the end of the document.
 """
 struct Document{T<:NamedTuple}
@@ -36,7 +38,7 @@ function process_document(str::AbstractString)
 end
 
 function process_punct(str::AbstractString)
-    return replace(str, r"[.!?><\\-]" => " ")
+    return replace(str, r"[.!?><\-\n\r\v\t\f]" => " ")
 end
 
 """

--- a/src/core.jl
+++ b/src/core.jl
@@ -77,6 +77,23 @@ struct Query <: AbstractQuery
     Query(str::AbstractString) = new(process_punct(str))
 end
 
+"""
+    Base.match(query::AbstractQuery, document::Document)
+
+Looks for a match for `query` in `document`. Returns either `nothing`
+if no match is found, or a [`QueryMatch`](@ref) object.
+"""
+Base.match(query::AbstractQuery, document::Document)
+
+
+"""
+    match_all(query::AbstractQuery, document::Document)
+
+Looks for all matches for `query` in the document. Returns a
+`Vector` `QueryMatch` objects corresponding to all of the matches found.
+"""
+match_all(query::AbstractQuery, document::Document)
+
 function Base.match(Q::Query, R::Document)
     if (length(R.text) < length(Q.text)) || (length(Q.text) == 0)
         return nothing

--- a/src/core.jl
+++ b/src/core.jl
@@ -75,23 +75,6 @@ struct Query <: AbstractQuery
     Query(str::AbstractString) = new(process_punct(str))
 end
 
-
-"""
-    Base.match(query::AbstractQuery, text::Union{Document,Corpus})
-
-Looks for a match for `query` in the text. Returns either `nothing`
-if no match is found, or a [`QueryMatch`](@ref) object.
-"""
-Base.match(query::AbstractQuery, text::Union{Document,Corpus})
-
-"""
-    match_all(query::AbstractQuery, text::Union{Document,Corpus})
-
-Looks for all matches for `query` in the text. Returns either a
-`Vector` `QueryMatch` objects corresponding to all of the matches found.
-"""
-match_all(query::AbstractQuery, text::Union{Document,Corpus})
-
 function Base.match(Q::Query, R::Document)
     if (length(R.text) < length(Q.text)) || (length(Q.text) == 0)
         return nothing

--- a/src/corpus.jl
+++ b/src/corpus.jl
@@ -20,7 +20,6 @@ struct Corpus{T<:NamedTuple,D}
     end
 end
 
-
 function Base.match(query::AbstractQuery, p::Corpus)
     for r in p.documents
         m = match(query, r)
@@ -34,7 +33,6 @@ end
 function match_all(query::AbstractQuery, p::Corpus)
     return reduce(vcat, (match_all(query, document) for document in p.documents))
 end
-
 
 """
     Base.match(query::AbstractQuery, corpus::Corpus)

--- a/src/corpus.jl
+++ b/src/corpus.jl
@@ -20,6 +20,7 @@ struct Corpus{T<:NamedTuple,D}
     end
 end
 
+
 function Base.match(query::AbstractQuery, p::Corpus)
     for r in p.documents
         m = match(query, r)

--- a/src/corpus.jl
+++ b/src/corpus.jl
@@ -36,19 +36,20 @@ function match_all(query::AbstractQuery, p::Corpus)
 end
 
 
+"""
+    Base.match(query::AbstractQuery, corpus::Corpus)
+
+Looks for a match for `query` in any [`Document`](@ref) in `corpus`.
+Returns either `nothing` if no match is found in any `Document`,
+or a [`QueryMatch`](@ref) object.
+"""
+Base.match(query::AbstractQuery, corpus::Corpus)
 
 """
-    Base.match(query::AbstractQuery, text::Union{Document,Corpus})
+    match_all(query::AbstractQuery, corpus::Corpus)
 
-Looks for a match for `query` in the text. Returns either `nothing`
-if no match is found, or a [`QueryMatch`](@ref) object.
+Looks for all matches for `query` from all documents in `corpus`. Returns a
+`Vector` of `QueryMatch` objects corresponding to all of the matches found,
+across all doucments.
 """
-Base.match(query::AbstractQuery, text::Union{Document,Corpus})
-
-"""
-    match_all(query::AbstractQuery, text::Union{Document,Corpus})
-
-Looks for all matches for `query` in the text. Returns either a
-`Vector` `QueryMatch` objects corresponding to all of the matches found.
-"""
-match_all(query::AbstractQuery, text::Union{Document,Corpus})
+match_all(query::AbstractQuery, corpus::Corpus)

--- a/src/corpus.jl
+++ b/src/corpus.jl
@@ -34,3 +34,21 @@ end
 function match_all(query::AbstractQuery, p::Corpus)
     return reduce(vcat, (match_all(query, document) for document in p.documents))
 end
+
+
+
+"""
+    Base.match(query::AbstractQuery, text::Union{Document,Corpus})
+
+Looks for a match for `query` in the text. Returns either `nothing`
+if no match is found, or a [`QueryMatch`](@ref) object.
+"""
+Base.match(query::AbstractQuery, text::Union{Document,Corpus})
+
+"""
+    match_all(query::AbstractQuery, text::Union{Document,Corpus})
+
+Looks for all matches for `query` in the text. Returns either a
+`Vector` `QueryMatch` objects corresponding to all of the matches found.
+"""
+match_all(query::AbstractQuery, text::Union{Document,Corpus})

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -6,7 +6,7 @@ Currently only supports agumenting (spaces or hyphens) with (spaces, no spaces).
 
 ## Example
 
-```julia
+```jldoctest
 julia> KeywordSearch.augment("arctic wolf")
 2-element Array{String,1}:
  "arctic wolf"
@@ -39,21 +39,35 @@ function augment(Q::AbstractQuery)
     return Or(Tuple(make_q.(augment(Q.text))))
 end
 
-"""
+# `raw` needed due to the `\n` in the test
+@doc raw"""
     word_boundary(Q::AbstractQuery) -> AbstractQuery
 
 Ensures that a word or phrase is not hyphenated or conjoined with the surrounding text.
 
-## Examples
+## Example
 
-```julia
-using KeywordSearch, Test, UUIDs
-query = Query("word")
-@test match(query, Document("This matchesword ", uuid4())) !== nothing
-@test match(word_boundary(query), Document("This matches word.", uuid4())) !== nothing
-@test match(word_boundary(query), Document("This matches word ", uuid4())) !== nothing
-@test match(word_boundary(query), Document("This matches word\nNext line", uuid4())) !== nothing
-@test match(word_boundary(query), Document("This doesn't matchword ", uuid4())) === nothing
+```jldoctest
+julia> using KeywordSearch, Test
+
+julia> query = Query("word")
+Query("word")
+
+julia> @test match(query, Document("This matchesword ")) !== nothing
+Test Passed
+
+julia> @test match(word_boundary(query), Document("This matches word.")) !== nothing
+Test Passed
+
+julia> @test match(word_boundary(query), Document("This matches word ")) !== nothing
+Test Passed
+
+julia> @test match(word_boundary(query), Document("This matches word\nNext line")) !== nothing
+Test Passed
+
+julia> @test match(word_boundary(query), Document("This doesn't matchword ")) === nothing
+Test Passed
+
 ```
 """
 function word_boundary(Q::AbstractQuery)

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -48,7 +48,7 @@ Ensures that a word or phrase is not hyphenated or conjoined with the surroundin
 ## Example
 
 ```jldoctest
-julia> using KeywordSearch, Test
+julia> using Test
 
 julia> query = Query("word")
 Query("word")

--- a/src/names.jl
+++ b/src/names.jl
@@ -132,8 +132,6 @@ object which was matched.
 ## Example
 
 ```jldoctest
-julia> using KeywordSearch
-
 julia> document_1 = Document("One", (; document_name = "a"))
 Document with text "One ". Metadata: (document_name = "a",)
 

--- a/src/names.jl
+++ b/src/names.jl
@@ -77,6 +77,12 @@ for OT in (:Corpus, :Document)
         m === nothing && return nothing
         return NamedMatch(m, (; Q.metadata..., obj.metadata..., m.haystack.metadata...))
     end
+
+    @eval function match_all(Q::NamedQuery, obj::$(OT))
+        disjoint_keys_check(Q, obj)
+        matches = match_all(Q.query, obj)
+        return [NamedMatch(m, (; Q.metadata..., obj.metadata..., m.haystack.metadata...)) for m in matches]
+    end
 end
 
 """

--- a/src/names.jl
+++ b/src/names.jl
@@ -1,3 +1,49 @@
+
+"""
+    NamedMatch{T,M<:QueryMatch}
+
+This object has two fields,
+
+* `match::M`, which holds a `QueryMatch` object corresponding to the match
+* and `metadata::T`, which holds a `NamedTuple` of metadata.
+
+and is created by the method [`match(query::NamedQuery, obj)`](@ref).
+
+`NamedMatch` satisfies the Tables.jl `AbstractRow` interface. This means that
+a vector of `NamedMatch` objects is a valid Tables.jl-compatible table.
+
+## Example
+
+```jldoctest
+julia> document_1 = Document("one", (; document_name = "a"))
+Document with text "one ". Metadata: (document_name = "a",)
+
+julia> document_2 = Document("Two but there's also a one here.", (; document_name = "b"))
+Document starting with "Two but there's…". Metadata: (document_name = "b",)
+
+julia> query = NamedQuery(Query("one"), "find one")
+NamedQuery
+├─ (query_name = "find one",)
+└─ Query("one")
+
+julia> matches = match_all(query, Corpus([document_1, document_2], (;corpus_name="corpus")));
+
+
+julia> using Tables
+
+
+julia> Tables.istable(matches)
+true
+
+julia> Tables.schema(Tables.rowtable(matches))
+Tables.Schema:
+ :match          …  KeywordSearch.QueryMatch{Query,Document{NamedTuple{(:document_name,),Tuple{String}}},Int64,UnitRange{Int64}}
+ :query_name        String
+ :corpus_name       String
+ :document_name     String
+
+```
+"""
 struct NamedMatch{T,M<:QueryMatch}
     match::M
     metadata::T
@@ -42,16 +88,6 @@ Tables.isrowtable(::Type{<:AbstractVector{<:NamedMatch}}) = true
 
 explain(io::IO, m::NamedMatch; context=40) = explain(io, m.match; context=context)
 
-"""
-    NamedMatch
-
-This object has two fields, `match` and `metadata`, and is created by
-the method `match(query::NamedQuery, obj)`. `NamedMatch` satisfies the
-Tables.jl `AbstractRow` interface. This means that a vector of `NamedMatch`
-objects is a valid Tables.jl-compatible table.
-"""
-NamedMatch
-
 struct NamedQuery{T<:NamedTuple,Q<:AbstractQuery} <: AbstractQuery
     query::Q
     metadata::T
@@ -95,7 +131,9 @@ object which was matched.
 
 ## Example
 
-```julia
+```jldoctest
+julia> using KeywordSearch
+
 julia> document_1 = Document("One", (; document_name = "a"))
 Document with text "One ". Metadata: (document_name = "a",)
 
@@ -109,13 +147,13 @@ Corpus metadata: (corpus_name = "Numbers",)
 julia> query = NamedQuery(FuzzyQuery("one"), "find one")
 NamedQuery
 ├─ (query_name = "find one",)
-└─ FuzzyQuery("one", DamerauLevenshtein(), 2)
+└─ FuzzyQuery("one", DamerauLevenshtein{Nothing}(nothing), 2)
 
 julia> m = match(query, corpus)
 NamedMatch
 ├─ (query_name = "find one", corpus_name = "Numbers", document_name = "a")
 └─ QueryMatch with distance 1 at indices 1:3.
-   ├─ FuzzyQuery("one", DamerauLevenshtein(), 2)
+   ├─ FuzzyQuery("one", DamerauLevenshtein{Nothing}(nothing), 2)
    └─ Document with text "One ". Metadata: (document_name = "a",)
 
 julia> m.metadata

--- a/src/names.jl
+++ b/src/names.jl
@@ -37,10 +37,13 @@ true
 
 julia> Tables.schema(Tables.rowtable(matches))
 Tables.Schema:
- :match          …  KeywordSearch.QueryMatch{Query,Document{NamedTuple{(:document_name,),Tuple{String}}},Int64,UnitRange{Int64}}
- :query_name        String
- :corpus_name       String
- :document_name     String
+ :haystack       Document{NamedTuple{(:document_name,),Tuple{String}}}
+ :distance       Int64
+ :indices        UnitRange{Int64}
+ :query          Query
+ :query_name     String
+ :corpus_name    String
+ :document_name  String
 
 ```
 """

--- a/src/names.jl
+++ b/src/names.jl
@@ -117,7 +117,8 @@ for OT in (:Corpus, :Document)
     @eval function match_all(Q::NamedQuery, obj::$(OT))
         disjoint_keys_check(Q, obj)
         matches = match_all(Q.query, obj)
-        return [NamedMatch(m, (; Q.metadata..., obj.metadata..., m.haystack.metadata...)) for m in matches]
+        return [NamedMatch(m, (; Q.metadata..., obj.metadata..., m.haystack.metadata...))
+                for m in matches]
     end
 end
 

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -34,6 +34,36 @@ function print_tree_rstrip(io::IO, x)
     return nothing
 end
 
+"""
+    Base.show(io::IO, q::Union{Or,NamedQuery,NamedMatch})
+
+[`Or`]@(ref), [`NamedQuery`](@ref), and [`NamedMatch`](@ref) are
+pretty-printed as trees.
+
+## Example
+
+```jldoctest
+julia> q = Query("a") | Query("b")
+Or
+├─ Query("a")
+└─ Query("b")
+
+julia> named = NamedQuery(q, "is it a or is it b?")
+NamedQuery
+├─ (query_name = "is it a or is it b?",)
+└─ Or
+   ├─ Query("a")
+   └─ Query("b")
+
+julia> match(named, Document("It is a!"))
+NamedMatch
+├─ (query_name = "is it a or is it b?",)
+└─ QueryMatch with distance 0 at indices 7:7.
+   ├─ Query("a")
+   └─ Document with text "It is a  ". Metadata: NamedTuple()
+
+```
+"""
 Base.show(io::IO, q::Union{Or,NamedQuery,NamedMatch}) = print_tree_rstrip(io, q)
 
 # `text_left_endpoint` and `text_right_endpoint` could be combined
@@ -80,29 +110,66 @@ function text_right_endpoint(text::AbstractString, start=1; approx_length=15)
     return R, "…"
 end
 
-function Base.show(io::IO, R::Document)
-    n, rdots = text_right_endpoint(R.text)
+"""
+    Base.show(io::IO, D::Document)
 
-    show_full_text = (length(R.text) < 15) || rdots == ""
+Pretty-prints a [`Document`](@ref).
+
+# Example
+```jldoctest
+
+julia> Document("Doc 1", (; doc_idx = 1)) # short documents print completely
+Document with text "Doc 1 ". Metadata: (doc_idx = 1,)
+
+julia> Document("This is a longer document! Lots of words here.", (; doc_idx = 1)) # longer documents print truncated
+Document starting with "This is a longer…". Metadata: (doc_idx = 1,)
+
+````
+"""
+function Base.show(io::IO, D::Document)
+    n, rdots = text_right_endpoint(D.text)
+
+    show_full_text = (length(D.text) < 15) || rdots == ""
     if show_full_text
         print(io, "Document with text ")
-        show(io, R.text)
+        show(io, D.text)
     else
         print(io, "Document starting with ")
-        print(io, "\"", R.text[1:n], rdots, "\"")
+        print(io, "\"", D.text[1:n], rdots, "\"")
     end
     print(io, ". Metadata: ")
-    show(io, R.metadata)
+    show(io, D.metadata)
     return nothing
 end
 
-function Base.show(io::IO, P::Corpus{T,TR}) where {T,TR}
+"""
+    Base.show(io::IO, C::Corpus)
+
+Pretty-prints a [`Corpus`](@ref).
+
+## Example
+
+```jldoctest
+julia> C1 = Corpus([Document("Doc 1", (; doc_idx = 1)), Document("Doc 2", (; doc_idx = 2))], (; name = "Lots of docs"))
+Corpus with 2 documents, each with metadata keys: (:doc_idx,)
+Corpus metadata: (name = "Lots of docs",)
+
+julia> C2 = Corpus([Document("a")], (; a = 1));
+
+julia> Set([C1, C2]) # compact printing is supported
+Set{Corpus} with 2 elements:
+  Corpus with 1 documents, each with metadata keys: ()…
+  Corpus with 2 documents, each with metadata keys: (:doc_idx,)…
+
+````
+"""
+function Base.show(io::IO, C::Corpus{T,TR}) where {T,TR}
     compact = get(io, :compact, false)
-    print(io, "Corpus with ", length(P.documents), " documents, each with metadata keys: ")
+    print(io, "Corpus with ", length(C.documents), " documents, each with metadata keys: ")
     print(io, _nt_names(TR))
 
     if !compact
-        print(io, "\nCorpus metadata: ", P.metadata)
+        print(io, "\nCorpus metadata: ", C.metadata)
     end
 end
 
@@ -125,7 +192,8 @@ function printcontext(io::IO, m::QueryMatch; context=40)
     return nothing
 end
 
-"""
+# `raw` due to escaped quotes in `sprint(explain...)`
+@doc raw"""
     explain([io=stdout], match; context=40)
 
 Prints a human-readable explanation of the match
@@ -133,9 +201,7 @@ and its context in the document in which it was found.
 
 ## Example
 
-```julia
-julia> using KeywordSearch
-
+```jldoctest
 julia> document = Document("The crabeating macacue ate a crab.")
 Document starting with "The crabeating macacue…". Metadata: NamedTuple()
 
@@ -147,11 +213,22 @@ Or
 └─ FuzzyQuery("crabeatingmacaque", DamerauLevenshtein{Nothing}(nothing), 2)
 
 julia> m = match(query, document)
-QueryMatch with distance 1 at indices 
-5:22.
+QueryMatch with distance 1 at indices 5:22.
 
 julia> explain(m)
 The query "crabeating macaque" matched the text "The crabeating macacue ate a crab  " with distance 1.
+
+julia> explain(m; context=5) # tweak the amount of context printed
+The query "crabeating macaque" matched the text "The crabeating macacue ate…" with distance 1.
+
+julia> sprint(explain, m) # to get the explanation as a string
+"The query \"crabeating macaque\" matched the text \"The crabeating macacue ate a crab  \" with distance 1.\n"
+
+julia> explain(match(Query("crab"), document)) # exact queries print slightly differently
+The query "crab" exactly matched the text "The crabeating macacue ate a crab  ".
+
+julia> explain(match(NamedQuery(Query("crab"), "crab query"), document)) # `NamedQuery`s print the same as their underlying query
+The query "crab" exactly matched the text "The crabeating macacue ate a crab  ".
 
 ```
 """
@@ -184,6 +261,19 @@ end
 
 explain(m; context=40) = explain(stdout, m; context=context)
 
+"""
+    Base.show(io::IO, m::QueryMatch)
+
+Pretty-prints a [`QueryMatch`](@ref).
+
+## Example
+
+```jldoctest
+julia> match(Query("claws"), Document("Lemurs have nails instead of claws."))
+QueryMatch with distance 0 at indices 30:34.
+
+````
+"""
 function Base.show(io::IO, m::QueryMatch)
     return print(io, "QueryMatch with distance ", m.distance, " at indices ", m.indices,
                  ".")

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -124,7 +124,7 @@ Document with text "Doc 1 ". Metadata: (doc_idx = 1,)
 julia> Document("This is a longer document! Lots of words here.", (; doc_idx = 1)) # longer documents print truncated
 Document starting with "This is a longer…". Metadata: (doc_idx = 1,)
 
-````
+```
 """
 function Base.show(io::IO, D::Document)
     n, rdots = text_right_endpoint(D.text)
@@ -161,7 +161,7 @@ Set{Corpus} with 2 elements:
   Corpus with 1 documents, each with metadata keys: ()…
   Corpus with 2 documents, each with metadata keys: (:doc_idx,)…
 
-````
+```
 """
 function Base.show(io::IO, C::Corpus{T,TR}) where {T,TR}
     compact = get(io, :compact, false)
@@ -272,7 +272,7 @@ Pretty-prints a [`QueryMatch`](@ref).
 julia> match(Query("claws"), Document("Lemurs have nails instead of claws."))
 QueryMatch with distance 0 at indices 30:34.
 
-````
+```
 """
 function Base.show(io::IO, m::QueryMatch)
     return print(io, "QueryMatch with distance ", m.distance, " at indices ", m.indices,

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -156,21 +156,23 @@ Corpus metadata: (name = "Lots of docs",)
 
 julia> C2 = Corpus([Document("a")], (; a = 1));
 
-julia> Set([C1, C2]) # compact printing is supported
-Set{Corpus} with 2 elements:
-  Corpus with 1 documents, each with metadata keys: ()…
-  Corpus with 2 documents, each with metadata keys: (:doc_idx,)…
+julia> [C1, C2]
+2-element Array{Corpus,1}:
+ Corpus with 2 documents, each with metadata keys: (:doc_idx,)
+ Corpus with 1 documents, each with metadata keys: ()
 
 ```
 """
 function Base.show(io::IO, C::Corpus{T,TR}) where {T,TR}
-    compact = get(io, :compact, false)
     print(io, "Corpus with ", length(C.documents), " documents, each with metadata keys: ")
     print(io, _nt_names(TR))
+    return nothing
+end
 
-    if !compact
-        print(io, "\nCorpus metadata: ", C.metadata)
-    end
+function Base.show(io::IO, ::MIME"text/plain", C::Corpus{T,TR}) where {T,TR}
+    show(io, C)
+    print(io, "\nCorpus metadata: ", C.metadata)
+    return nothing
 end
 
 function printcontext(io::IO, m::QueryMatch; context=40)

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -125,6 +125,38 @@ function printcontext(io::IO, m::QueryMatch; context=40)
     return nothing
 end
 
+"""
+    explain([io=stdout], match; context=40)
+
+Prints a human-readable explanation of the match
+and its context in the document in which it was found.
+
+## Example
+
+```julia
+julia> using KeywordSearch
+
+julia> document = Document("The crabeating macacue ate a crab.")
+Document starting with "The crabeating macacue…". Metadata: NamedTuple()
+
+julia> query = augment(FuzzyQuery("crab-eating macaque"))
+Or
+├─ FuzzyQuery("crab eating macaque", DamerauLevenshtein{Nothing}(nothing), 2)
+├─ FuzzyQuery("crabeating macaque", DamerauLevenshtein{Nothing}(nothing), 2)
+├─ FuzzyQuery("crab eatingmacaque", DamerauLevenshtein{Nothing}(nothing), 2)
+└─ FuzzyQuery("crabeatingmacaque", DamerauLevenshtein{Nothing}(nothing), 2)
+
+julia> m = match(query, document)
+QueryMatch with distance 1 at indices 
+5:22.
+
+julia> explain(m)
+The query "crabeating macaque" matched the text "The crabeating macacue ate a crab  " with distance 1.
+
+```
+"""
+explain
+
 function explain(io::IO, m::QueryMatch{<:FuzzyQuery}; context=40)
     print(io, "The query ")
     show(io, m.query.text)

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -116,8 +116,8 @@ end
 Pretty-prints a [`Document`](@ref).
 
 # Example
-```jldoctest
 
+```jldoctest
 julia> Document("Doc 1", (; doc_idx = 1)) # short documents print completely
 Document with text "Doc 1 ". Metadata: (doc_idx = 1,)
 

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -222,7 +222,7 @@ julia> explain(m; context=5) # tweak the amount of context printed
 The query "crabeating macaque" matched the text "The crabeating macacue ate…" with distance 1.
 
 julia> sprint(explain, m) # to get the explanation as a string
-"The query \"crabeating macaque\" matched the text \"The crabeating macacue ate a crab  \" with distance 1.\n"
+"The query \\"crabeating macaque\\" matched the text \\"The crabeating macacue ate a crab  \\" with distance 1.\n"
 
 julia> explain(match(Query("crab"), document)) # exact queries print slightly differently
 The query "crab" exactly matched the text "The crabeating macacue ate a crab  ".

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -389,6 +389,17 @@ end
     @test match_all(Query("eating"), C1) ==
           [match(Query("eating"), D1), match(Query("eating"), D2)]
 
+    eating_query = NamedQuery(Query("eating"), "eating query")
+    matches = match_all(eating_query, C1)
+    @test length(matches) == 2
+    @test matches[1].metadata == (; query_name = "eating query", corpus_uuid = C1.metadata.corpus_uuid, document_uuid = D1.metadata.document_uuid)
+    @test matches[2].metadata == (; query_name = "eating query", corpus_uuid = C1.metadata.corpus_uuid, document_uuid = D2.metadata.document_uuid)
+          
+    D1_matches = match_all(eating_query, D1)
+    @test length(D1_matches) == 1
+    @test D1_matches[1].metadata == (; query_name = "eating query", document_uuid = D1.metadata.document_uuid)
+    @test D1_matches[1].match == matches[1].match
+
     D3 = Document("There were king cobras", (; document_uuid=uuid4()))
     d_uuid = uuid4()
     D4 = Document("There were other cobras", (; document_uuid=d_uuid))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,13 +102,6 @@ end
     # we count hyphens as a word boundary here (since we remove them from the documents and queries)
     @test match(word_boundary(Query("ant")), Document("This matches-ant")) !== nothing
 
-    # from `word_boundary` docstring
-    query = Query("word")
-    @test match(query, Document("This matchesword ")) !== nothing
-    @test match(word_boundary(query), Document("This matches word.")) !== nothing
-    @test match(word_boundary(query), Document("This matches word ")) !== nothing
-    @test match(word_boundary(query), Document("This matches word\nNext line")) !== nothing
-    @test match(word_boundary(query), Document("This doesn't matchword ")) === nothing
 end
 
 ## A more representative test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,8 @@ function with_replacements(f, replaces...)
 end
 
 @testset "Doctests" begin
-    DocMeta.setdocmeta!(KeywordSearch, :DocTestSetup, :(using KeywordSearch); recursive=true)
+    DocMeta.setdocmeta!(KeywordSearch, :DocTestSetup, :(using KeywordSearch);
+                        recursive=true)
     Documenter.doctest(KeywordSearch)
 end
 
@@ -101,7 +102,6 @@ end
 
     # we count hyphens as a word boundary here (since we remove them from the documents and queries)
     @test match(word_boundary(Query("ant")), Document("This matches-ant")) !== nothing
-
 end
 
 ## A more representative test
@@ -336,12 +336,17 @@ end
     eating_query = NamedQuery(Query("eating"), "eating query")
     matches = match_all(eating_query, C1)
     @test length(matches) == 2
-    @test matches[1].metadata == (; query_name = "eating query", corpus_uuid = C1.metadata.corpus_uuid, document_uuid = D1.metadata.document_uuid)
-    @test matches[2].metadata == (; query_name = "eating query", corpus_uuid = C1.metadata.corpus_uuid, document_uuid = D2.metadata.document_uuid)
-          
+    @test matches[1].metadata ==
+          (; query_name="eating query", corpus_uuid=C1.metadata.corpus_uuid,
+           document_uuid=D1.metadata.document_uuid)
+    @test matches[2].metadata ==
+          (; query_name="eating query", corpus_uuid=C1.metadata.corpus_uuid,
+           document_uuid=D2.metadata.document_uuid)
+
     D1_matches = match_all(eating_query, D1)
     @test length(D1_matches) == 1
-    @test D1_matches[1].metadata == (; query_name = "eating query", document_uuid = D1.metadata.document_uuid)
+    @test D1_matches[1].metadata ==
+          (; query_name="eating query", document_uuid=D1.metadata.document_uuid)
     @test D1_matches[1].match == matches[1].match
 
     D3 = Document("There were king cobras", (; document_uuid=uuid4()))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,14 @@ end
 
     # we count hyphens as a word boundary here (since we remove them from the documents and queries)
     @test match(word_boundary(Query("ant")), Document("This matches-ant")) !== nothing
+
+    # from `word_boundary` docstring
+    query = Query("word")
+    @test match(query, Document("This matchesword ")) !== nothing
+    @test match(word_boundary(query), Document("This matches word.")) !== nothing
+    @test match(word_boundary(query), Document("This matches word ")) !== nothing
+    @test match(word_boundary(query), Document("This matches word\nNext line")) !== nothing
+    @test match(word_boundary(query), Document("This doesn't matchword ")) === nothing
 end
 
 ## A more representative test


### PR DESCRIPTION
I realized that after #8 some docstrings I didn't want to include (e.g. `_findmin`, which hopefully will be gone soon, ref #9) were there, and others didn't exist (e.g. `match` and `explain`). So here I've tried to fix that.