### PR TITLE
Some small CI script, docs project, and testing tweaks

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,4 +12,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/push_preview_cleanup.yml
+++ b/.github/workflows/push_preview_cleanup.yml
@@ -1,9 +1,8 @@
+# from https://juliadocs.github.io/Documenter.jl/dev/man/hosting/#gh-pages-Branch
 name: Doc Preview Cleanup
-
 on:
   pull_request:
     types: [closed]
-
 jobs:
   doc-preview-cleanup:
     runs-on: ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -11,14 +11,16 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 AbstractTrees = "0.3"
+Aqua = "0.5"
 StringDistances = "0.10"
 Tables = "1"
 julia = "1.5"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Suppressor"]
+test = ["Aqua", "Test", "Random", "Suppressor"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,6 @@ KeywordSearch = "f977ba8c-7144-47e8-b06b-e3f658952959"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]
+DataFrames = "0.22"
 Documenter = "0.25"
+Transducers = "0.4"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using KeywordSearch, Test, UUIDs, Random
 using Tables, StringDistances, Suppressor
+using Aqua
 
 # easier stateless testing of the global `KeywordSearch.AUTOMATIC_REPLACEMENTS`
 # by emptying it, adding replacements, calling `f`, then restoring the former
@@ -465,4 +466,8 @@ end
     @test_throws ErrorException match(NamedQuery(Query("a"), (; uuid=uuid4())),
                                       Corpus([Document("abc", (; uuid=uuid4()))],
                                               (; corpus_name="a")))
+end
+
+@testset "Aqua tests" begin
+    Aqua.test_all(KeywordSearch)
 end


### PR DESCRIPTION
The most notable is adding [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) as a test-time dependency to do some basic checks:

> * There are no method ambiguities.
> * There are no undefined exports.
> * There are no unbound type parameters.
> * There are no stale dependencies listed in Project.toml.
> * Check that test target of the root project Project.toml and test project (test/Project.toml) are consistent.
> * Check that all external packages listed in deps have corresponding compat entry.
> * Project.toml formatting is compatible with Pkg.jl output.

Note that Aqua itself has no dependencies and therefore having it as a test-only dependency should not mess up package resolution at test time. (What do I mean? At Beacon we had an internal application/library with both a Manifest.toml and tests, and I added a test-only dependency which itself has a bunch of dependencies, and at test time, Pkg could not find a version of this test dependency compatible with the existing Manifest, and would error out. Here that isn't a concern since KeywordSearch is purely a library and does not have a checked-in Manifest, but it could be for introducing test-only deps like Aqua to other projects).

Note that the compat checks don't extend to the docs project (ref https://github.com/JuliaTesting/Aqua.jl/issues/51).