### PR TITLE
use `AUTOMATIC_REPLACEMENTS` instead of separate `punct_preprocess` function

### DIFF
--- a/src/KeywordSearch.jl
+++ b/src/KeywordSearch.jl
@@ -7,14 +7,27 @@ using Tables
 export DamerauLevenshtein, FuzzyQuery, Query, Corpus, Document
 export augment, explain, match_all, word_boundary, NamedQuery
 
-"""
-    const AUTOMATIC_REPLACEMENTS::Vector{Pair{String, String}}
+@doc raw"""
+    const AUTOMATIC_REPLACEMENTS::Vector{Pair{Union{Regex,String},String}}
 
 A list of replacements to automatically perform when preprocessing a [`Document`](@ref).
 For example, if `KeywordSearch.AUTOMATIC_REPLACEMENTS == ["a" => "b"]`, then
 `Document("abc").text == "bbc"` instead of "abc".
+
+By default, `AUTOMATIC_REPLACEMENTS` contains only one replacement,
+
+```julia
+r"[.!?><\-\n\r\v\t\f]" => " "
+```
+
+which replaces certain punctuation characters, whitespace, and newlines with a space.
+This replacement is needed for [`word_boundary`](@ref) to work correctly, but you
+can remove it with `empty!(KeywordSearch.AUTOMATIC_REPLACEMENTS)` if you wish.
+
+You an also add other preprocessing directives by `push!`ing further replacements
+into `KeywordSearch.AUTOMATIC_REPLACEMENTS`.
 """
-const AUTOMATIC_REPLACEMENTS = Pair{String,String}[]
+const AUTOMATIC_REPLACEMENTS = Pair{Union{Regex,String},String}[r"[.!?><\-\n\r\v\t\f]" => " "]
 
 include("core.jl")
 include("corpus.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -28,7 +28,6 @@ end
 
 Document(text::AbstractString) = Document(text, NamedTuple())
 
-
 function apply_replacements(str::AbstractString)
     # Apply automatic replacements
     # using https://github.com/JuliaLang/julia/issues/29849#issuecomment-449535743


### PR DESCRIPTION
This means you can easily override the punctuation preprocessing just by modifying `AUTOMATIC_REPLACEMENTS`; before, there wasn't a legitimate way to do so (you could pirate `preprocess_punct` though of course). I think it also makes it clearer what's going on.
