### PR TITLE
`whitespace_typedefs=false` unnecessary

### DIFF
--- a/format/run.jl
+++ b/format/run.jl
@@ -1,8 +1,7 @@
 using JuliaFormatter
 
 function main()
-    perfect = format(joinpath(@__DIR__, ".."); style=YASStyle(), whitespace_typedefs=false,
-                     verbose=true)
+    perfect = format(joinpath(@__DIR__, ".."); style=YASStyle(), verbose=true)
     if perfect
         @info "Linting complete - no files altered"
     else


### PR DESCRIPTION
I went to upstream our choice of `whitespace_typedefs=false` to YASStyle in JuliaFormatter when I realized it's already the default (overall, not just in YASStyle: https://github.com/domluna/JuliaFormatter.jl/blob/v0.11.0/src/options.jl). This can be tested by the format check passing here without code changes :).