### PR TITLE
tweak names of github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
       - 'Project.toml'
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Test (Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,8 @@ on:
       - 'src/**'
       - 'docs/**'
 jobs:
-  build:
+  build-docs:
+    name: Build documentation (${{ github.event_name }})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -7,7 +7,8 @@ on:
     tags: '*'
   pull_request:
 jobs:
-  build:
+  format-check:
+    name: Format check (Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Hopefully this makes the status checks more clear (compared to e.g. https://github.com/beacon-biosignals/KeywordSearch.jl/pull/13 where there's just a bunch of "Julia 1 ..." and "build").