### PR TITLE
fix doctest script

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -4,20 +4,36 @@ on:
     branches:
       - 'main'
       - /^release-.*$/
-    tags: '*'
+    tags: ['*']
   pull_request:
 jobs:
   doctests:
-    name: Doctests (Julia ${{ matrix.julia-version }} - ${{ github.event_name }})
+    name: Doctests (Julia 1.6.2 - ${{ github.event_name }} - ${{ matrix.filter_mode }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        julia-version: [1.6.1]
+        include:
+          # We run and generate github suggestions on anywhere in the
+          # diff of the PR.
+          # We don't fail if there is a suggestion to make because we want
+          # to continue to the next step.
+          - fail_on_error: false
+            filter_mode: 'diff_context'
+
+          # We run once with no filter. That means we get
+          # "annotations" instead of suggestions (toggle them by pressing `a`
+          # while viewing the PR) and they can't be committed, but they can
+          # occur anywhere, not just in the diff of the PR. This time,
+          # we fail if there were any, because it means the doctests did not pass.
+          - fail_on_error: true
+            filter_mode: 'nofilter'
+
     steps:
       - uses: julia-actions/setup-julia@latest
         with:
-          version: ${{ matrix.julia-version }}
-      - uses: actions/checkout@v1
+          version: 1.6.2
+      - uses: actions/checkout@v2
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Fix doctests
@@ -26,8 +42,10 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: reviewdog/action-suggester@v1
         if: github.event_name == 'pull_request'
         with:
           tool_name: Documenter (doctests)
-          fail_on_error: true
+          fail_on_error: ${{ matrix.fail_on_error }}
+          filter_mode: ${{ matrix.filter_mode }}

--- a/src/names.jl
+++ b/src/names.jl
@@ -37,7 +37,7 @@ true
 
 julia> Tables.schema(Tables.rowtable(matches))
 Tables.Schema:
- :document       Document{NamedTuple{(:document_name,),Tuple{String}}}
+ :document       Document{NamedTuple{(:document_name,), Tuple{String}}}
  :distance       Int64
  :indices        UnitRange{Int64}
  :query          Query

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -157,7 +157,7 @@ Corpus metadata: (name = "Lots of docs",)
 julia> C2 = Corpus([Document("a")], (; a = 1));
 
 julia> [C1, C2]
-2-element Array{Corpus,1}:
+2-element Vector{Corpus}:
  Corpus with 2 documents, each with metadata keys: (:doc_idx,)
  Corpus with 1 documents, each with metadata keys: ()
 


### PR DESCRIPTION
Now we run two jobs:

* One does the `diff_context` which is the default, and generates github suggestions. However it only looks at the diff-- any doctests failing elsewhere are ignored.
* one uses the `nofilter` context and can only make "annotations" (like codecov). These you can toggle visibility by pressing "a". They aren't committable, just for awareness. The workflow will fail if there are any annotations, i.e. any changed doctests.

The previous way was only the first job.

I experimented with this on an internal repo, though I should've done it on a public one so everyone can see the experiments.

This addresses @christopher-dG's concern in https://github.com/beacon-biosignals/KeywordSearch.jl/pull/18#issuecomment-878303989.