### PR TITLE
Add initial space at the start of `Document`'s to fix word boundary bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeywordSearch"
 uuid = "f977ba8c-7144-47e8-b06b-e3f658952959"
 authors = ["Beacon Biosignals, Inc"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeywordSearch"
 uuid = "f977ba8c-7144-47e8-b06b-e3f658952959"
 authors = ["Beacon Biosignals, Inc"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/core.jl
+++ b/src/core.jl
@@ -19,9 +19,9 @@ struct Document{T<:NamedTuple}
     function Document(text::AbstractString, metadata::T) where {T}
         check_keys(T)
 
-        # Add a final space to ensure that the last word is recognized
+        # Add an initial and final space to ensure that the last word is recognized
         # as a word boundary.
-        new_text = apply_replacements(text) * " "
+        new_text = " " * apply_replacements(text) * " "
         return new{T}(new_text, metadata)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,11 @@ end
 
     # we count hyphens as a word boundary here (since we remove them from the documents and queries)
     @test match(word_boundary(Query("ant")), Document("This matches-ant")) !== nothing
+
+    # Test that the first/last word in a document can be matched by a word boundary
+    @test match(word_boundary(Query("abcd")), Document("abcd")) !== nothing
+    @test match(word_boundary(Query("abcd")), Document("abcd hello")) !== nothing
+    @test match(word_boundary(Query("abcd")), Document("hello abcd")) !== nothing
 end
 
 ## A more representative test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -378,7 +378,7 @@ end
               (:document, :distance, :indices, :query, :query_name, :corpus_uuid,
                :document_uuid)
         @test sprint(explain, (first(Tables.rowtable(tbl)))) ===
-              "The query \" other\" exactly matched the text \"There were other cobras \".\n"
+              "The query \" other\" exactly matched the text \" There were other cobras \".\n"
     end
 end
 


### PR DESCRIPTION
It's a little hacky how `word_boundary` works; it relies on the fact that we convert all punctuation to spaces, so it just adds a space to either side of the query. We made sure to add an extra space to the end of the document, but forgot one at the beginning.

Thanks @ararslan for the MWE