### PR TITLE
improve default `AUTOMATIC_REPLACEMENTS`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeywordSearch"
 uuid = "f977ba8c-7144-47e8-b06b-e3f658952959"
 authors = ["Beacon Biosignals, Inc"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/KeywordSearch.jl
+++ b/src/KeywordSearch.jl
@@ -14,10 +14,13 @@ A list of replacements to automatically perform when preprocessing a [`Document`
 For example, if `KeywordSearch.AUTOMATIC_REPLACEMENTS == ["a" => "b"]`, then
 `Document("abc").text == "bbc"` instead of "abc".
 
-By default, `AUTOMATIC_REPLACEMENTS` contains only one replacement,
+By default, `AUTOMATIC_REPLACEMENTS` contains only one replacement:
 
-```julia
-r"[.!?><\-\n\r\v\t\f]" => " "
+```jldoctest
+julia> KeywordSearch.AUTOMATIC_REPLACEMENTS
+1-element Vector{Pair{Union{Regex, String}, String}}:
+ r"[.!?><\-\n\r\v\t\f\s]+" => " "
+
 ```
 
 which replaces certain punctuation characters, whitespace, and newlines with a space.
@@ -27,7 +30,7 @@ can remove it with `empty!(KeywordSearch.AUTOMATIC_REPLACEMENTS)` if you wish.
 You an also add other preprocessing directives by `push!`ing further replacements
 into `KeywordSearch.AUTOMATIC_REPLACEMENTS`.
 """
-const AUTOMATIC_REPLACEMENTS = Pair{Union{Regex,String},String}[r"[.!?><\-\n\r\v\t\f]" => " "]
+const AUTOMATIC_REPLACEMENTS = Pair{Union{Regex,String},String}[r"[.!?><\-\v\f\s]+" => " "]
 
 include("core.jl")
 include("corpus.jl")

--- a/src/KeywordSearch.jl
+++ b/src/KeywordSearch.jl
@@ -19,7 +19,7 @@ By default, `AUTOMATIC_REPLACEMENTS` contains only one replacement:
 ```jldoctest
 julia> KeywordSearch.AUTOMATIC_REPLACEMENTS
 1-element Vector{Pair{Union{Regex, String}, String}}:
- r"[.!?><\-\n\r\v\t\f\s]+" => " "
+ r"[.!?><\-\v\f\s]+" => " "
 
 ```
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -18,10 +18,17 @@ struct Document{T<:NamedTuple}
 
     function Document(text::AbstractString, metadata::T) where {T}
         check_keys(T)
+        new_text = apply_replacements(text)
 
         # Add an initial and final space to ensure that the last word is recognized
-        # as a word boundary.
-        new_text = " " * apply_replacements(text) * " "
+        # as a word boundary, if necessary.
+        if !startswith(new_text, " ") && !endswith(new_text, " ")
+            new_text = string(" ", new_text, " ")
+        elseif !startswith(new_text, " ")
+            new_text = string(" ", new_text)
+        elseif !endswith(new_text, " ")
+            new_text = string(new_text, " ")
+        end
         return new{T}(new_text, metadata)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -392,7 +392,7 @@ end
         @test Document("   hello  !   goodbye   ??").text == " hello goodbye "
         @test Document("   hello   \n  goodbye   ??").text == " hello goodbye "
         @test Document("   hello \t\t  goodbye   ??").text == " hello goodbye "
-        
+
         # Make sure we can match them too:
         @test match(Query("hello goodbye"), Document("   hello     goodbye   ??")) !==
               nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,6 +385,23 @@ end
 @testset "`AUTOMATIC_REPLACEMENTS`" begin
     @test with_replacements(() -> Document("abc"), "a" => "b") ==
           with_replacements(() -> Document("bbc"))
+
+    @testset "Default replacements" begin
+        @test Document("????hello??.???").text == " hello "
+        @test Document("   hello     goodbye   ??").text == " hello goodbye "
+        @test Document("   hello  !   goodbye   ??").text == " hello goodbye "
+        @test Document("   hello   \n  goodbye   ??").text == " hello goodbye "
+
+        # Has tabs:
+        @test Document("   hello          goodbye   ??").text == " hello goodbye "
+        
+        # Make sure we can match them too:
+        @test match(Query("hello goodbye"), Document("   hello     goodbye   ??")) !== nothing
+        @test match(Query("hello ??? goodbye"), Document("   hello     goodbye   ??")) !== nothing
+
+        # this has got tabs too
+        @test match(Query("hello            \n goodbye"), Document("   hello     goodbye   ??")) !== nothing
+    end
 end
 
 ## Edge cases

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -394,13 +394,15 @@ end
 
         # Has tabs:
         @test Document("   hello          goodbye   ??").text == " hello goodbye "
-        
         # Make sure we can match them too:
-        @test match(Query("hello goodbye"), Document("   hello     goodbye   ??")) !== nothing
-        @test match(Query("hello ??? goodbye"), Document("   hello     goodbye   ??")) !== nothing
+        @test match(Query("hello goodbye"), Document("   hello     goodbye   ??")) !==
+              nothing
+        @test match(Query("hello ??? goodbye"), Document("   hello     goodbye   ??")) !==
+              nothing
 
         # this has got tabs too
-        @test match(Query("hello            \n goodbye"), Document("   hello     goodbye   ??")) !== nothing
+        @test match(Query("hello            \n goodbye"),
+                    Document("   hello     goodbye   ??")) !== nothing
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -391,16 +391,12 @@ end
         @test Document("   hello     goodbye   ??").text == " hello goodbye "
         @test Document("   hello  !   goodbye   ??").text == " hello goodbye "
         @test Document("   hello   \n  goodbye   ??").text == " hello goodbye "
-
-        # Has tabs:
-        @test Document("   hello          goodbye   ??").text == " hello goodbye "
+        @test Document("   hello \t\t  goodbye   ??").text == " hello goodbye "
         
         # Make sure we can match them too:
         @test match(Query("hello goodbye"), Document("   hello     goodbye   ??")) !== nothing
         @test match(Query("hello ??? goodbye"), Document("   hello     goodbye   ??")) !== nothing
-
-        # this has got tabs too
-        @test match(Query("hello            \n goodbye"), Document("   hello     goodbye   ??")) !== nothing
+        @test match(Query("hello   \t   \n goodbye"), Document("   hello     goodbye   ??")) !== nothing
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -400,6 +400,13 @@ end
     end
 end
 
+@testset "`Document` constructor start/end space" begin
+    @test Document("hello").text == " hello "
+    @test Document("hello ").text == " hello "
+    @test Document(" hello").text == " hello "
+    @test Document(" hello ").text == " hello "
+end
+
 ## Edge cases
 
 @testset "Query vs document lengths" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -394,9 +394,12 @@ end
         @test Document("   hello \t\t  goodbye   ??").text == " hello goodbye "
         
         # Make sure we can match them too:
-        @test match(Query("hello goodbye"), Document("   hello     goodbye   ??")) !== nothing
-        @test match(Query("hello ??? goodbye"), Document("   hello     goodbye   ??")) !== nothing
-        @test match(Query("hello   \t   \n goodbye"), Document("   hello     goodbye   ??")) !== nothing
+        @test match(Query("hello goodbye"), Document("   hello     goodbye   ??")) !==
+              nothing
+        @test match(Query("hello ??? goodbye"), Document("   hello     goodbye   ??")) !==
+              nothing
+        @test match(Query("hello   \t   \n goodbye"),
+                    Document("   hello     goodbye   ??")) !== nothing
     end
 end
 


### PR DESCRIPTION
Now we normalize out multiple spaces to be a single space, and make the regex more robust to multiple replacements, and add some much-needed tests.

Thanks to @ararslan for pointing out issues with this.